### PR TITLE
Enable to set sort at

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,24 +1,29 @@
 # Jinrai
-Jinraiはカーソルベースのページネータです。
+
+Jinrai はカーソルベースのページネータです。
 
 ## 使い方
+
 ```ruby
 # config/initializers/jinrai.rb
 
 Jinrai.configure do |config|
   config.default_cursor_per = 20 #=> User.cursor.count == 20
-  config.default_cursor_format = :id, :name #=> cursor format will be "#{user.id}_#{user.name}"
+  config.default_cursor_format = [:id, :name] #=> cursor format will be "#{user.id}_#{user.name}"
+  config.default_cursor_sort_at = :id
   config.default_cursor_sort_order = :desc
 end
 ```
 
 モデルごとにリクエスト毎のレコード返却件数, カーソルのフォーマットを指定することができます。
+
 ```ruby
 # app/model/user.rb
 
 class User < ApplicationRecord
   cursor_per 100
-  cursor_format :name, :age
+  cursor_format [:name, :age]
+  cursor_sort_at = :created_at # default: :id
   cursor_sort_order :asc # default: :desc
 end
 
@@ -34,21 +39,23 @@ User.after(cursor) # カーソルが指し示すレコード以降のデータ�
 User.before(cursor) # カーソルが指し示すレコード以前のデータを返します
 ```
 
-`.cursor`メソッドは `till`と`since`,`sort_at`の3つの引数を持っていて, 任意の範囲のレコードを取り出したり、特定の属性で並び替えることができます.
+`.cursor`メソッドは `till`と`since`,`sort_at`の 3 つの引数を持っていて, 任意の範囲のレコードを取り出したり、特定の属性で並び替えることができます.
+
 ```ruby
-since_cursor = User.cursor.till_cursor
-User.cursor(since: since_cursor) # since_cursor移行のレコードセットを返します
+next_cursor = User.cursor.next_cursor
+User.cursor(since: next_cursor) # next_cursor以降のレコードセットを返します
 
-till_cursor = User.cursor.since_cursor
-User.cursor(till: till_cursor) # till_cursor以前のレコードセットを返します
+prev_cursor = User.cursor.prev_cursor
+User.cursor(till: prev_cursor) # prev_cursor以前のレコードセットを返します
 
-# sinceとtillを同時に指定することもできて、この場合since_corsor以降、till_cursor以前の範囲に含まれるレコードの最新cursor_per件を返します.
-User.cursor(since: since_cursor, till: till_cursor)
+# sinceとtillを同時に指定することもできて、この場合since_corsor以降、prev_cursor以前の範囲に含まれるレコードの最新cursor_per件を返します.
+User.cursor(since: next_cursor, till: prev_cursor)
 ```
 
-カーソルはコレクションに対して`#since_cursor`, `#till_cursor`を呼び出すか、modelのインスタンスに対して`#to_cursor`を呼び出すことで取得できます。
+カーソルはコレクションに対して`#next_cursor`, `#prev_cursor`を呼び出すか、model のインスタンスに対して`#to_cursor`を呼び出すことで取得できます。
+
 ```ruby
 users = User.cursor
-users.since_cursor # コレクションの最初のレコードを指し示すカーソルを返します
-users.till_cursor # コレクションの最後のレコードを指し示すカーソルを返します
+users.next_cursor # コレクションの最後のレコードを指し示すカーソルを返します
+users.prev_cursor # コレクションの最初のレコードを指し示すカーソルを返します
 ```

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # Jinrai
+
 Jinrai is a awesome cursor based paginator
 
 ## Usage
+
 ```ruby
 # config/initializers/jinrai.rb
 
 Jinrai.configure do |config|
   config.default_cursor_per = 20 #=> User.cursor.count == 20
-  config.default_cursor_format = :id, :name #=> cursor format will be "#{user.id}_#{user.name}"
+  config.default_cursor_format = [:id, :name] #=> cursor format will be "#{user.id}_#{user.name}"
+  config.default_cursor_sort_at = :id
   config.default_cursor_sort_order = :desc
 end
 ```
@@ -17,7 +20,8 @@ end
 
 class User < ApplicationRecord
   cursor_per 100
-  cursor_format :name, :age
+  cursor_format [:name, :age]
+  cursor_sort_at = :created_at # default: :id
   cursor_sort_order :asc # default: :desc
 end
 
@@ -28,27 +32,33 @@ User.cursor.since_format #=> generate cursor fomatted "#{user.name}_#{user.age}"
 ```ruby
 User.cursor #=> get latest 20 records.
 User.cursor.count #=> 20
+
+User.after(cursor) # returns the data after the record pointed to by the cursor
+User.before(cursor) # returns the data before the record pointed to by the cursor
 ```
 
 `.cursor` has two arguments, `till` and `since`, and by passing them we can get record collection of arbitrary interval.
-```ruby
-since_cursor = User.cursor.till_cursor
-User.cursor(since: since_cursor) # return records older than the record pointed by the cursor
 
-till_cursor = User.cursor.since_cursor
-User.cursor(till: till_cursor) # return records newer than the record pointed by the cursor
+```ruby
+next_cursor = User.cursor.next_cursor
+User.cursor(since: next_cursor) # return records older than the record pointed by the cursor
+
+prev_cursor = User.cursor.prev_cursor
+User.cursor(till: prev_cursor) # return records newer than the record pointed by the cursor
 
 User.cursor(since: since_cursor, till: till_cursor) # return records newer than the record pointed by the since cursor and older than the record pointed by the till cursor.
 ```
 
-Get cursor by calling `since_cursor` or `till_cursor`.
+Get cursor by calling `next_cursor` or `prev_cursor`.
+
 ```ruby
 users = User.cursor
-users.since_cursor # this cursor points first record of User collection
-users.till_cursor # this cursor points last record of User collection
+users.next_cursor # this cursor points last record of User collection
+users.prev_cursor # this cursor points first record of User collection
 ```
 
 ## Installation
+
 Add this line to your application's Gemfile:
 
 ```ruby
@@ -56,38 +66,45 @@ gem 'jinrai'
 ```
 
 And then execute:
+
 ```bash
 $ bundle
 ```
 
 Or install it yourself as:
+
 ```bash
 $ gem install jinrai
 ```
 
 ## Contributing
+
 1. Fork then clone this repo:
+
 ```bash
 git clone git@github.com:YOUR_USERNAME/jinrai.git
 ```
 
 1. setup dependencies via bundler:
+
 ```bash
 bundle install
 ```
 
 1. Make sure the spec pass:
+
 ```bash
 bundle exec rspec
 ```
 
 1. Make your change, and write spec, make sure test pass:
+
 ```bash
-bandle exec rspec
+bundle exec rspec
 ```
 
 1. write a good commit message, push to your fork, then submit PullRequest.
 
-
 ## License
+
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/lib/jinrai/active_record/cursor_methods.rb
+++ b/lib/jinrai/active_record/cursor_methods.rb
@@ -9,11 +9,13 @@ module Jinrai
         return unless first
         encode_cursor(first)
       end
+      alias prev_cursor since_cursor
 
       def till_cursor
         return unless last
         encode_cursor(last)
       end
+      alias next_cursor till_cursor
 
       def per(num = nil)
         num ||= default_cursor_per

--- a/lib/jinrai/active_record/finder_methods.rb
+++ b/lib/jinrai/active_record/finder_methods.rb
@@ -49,7 +49,8 @@ module Jinrai
 
 
         def cursoring(rank, rank_for_primary, cursor, sort_at)
-          sort_at ||= primary_key
+
+          sort_at ||= default_cursor_sort_at
           if cursor
             attributes = default_attributes_from_cursor.call(decode_cursor(cursor))
             pointed = find_by!(attributes)

--- a/lib/jinrai/config.rb
+++ b/lib/jinrai/config.rb
@@ -14,12 +14,14 @@ module Jinrai #:nodoc:
   class Config #:nodoc:
     attr_accessor :default_cursor_per,
                   :default_cursor_format,
+                  :default_cursor_sort_at,
                   :default_cursor_sort_order,
                   :default_attributes_from_cursor
 
     def initialize
       @default_cursor_per = 20
-      @default_cursor_format = %i[created_at id]
+      @default_cursor_format = [:id]
+      @default_cursor_sort_at = :id
       @default_cursor_sort_order = :desc
       @default_attributes_from_cursor = Proc.new { |decoded_cursor| decoded_cursor }
     end

--- a/lib/jinrai/configuration_methods.rb
+++ b/lib/jinrai/configuration_methods.rb
@@ -13,6 +13,10 @@ module Jinrai #:nodoc:
         @_default_attributes_from_cursor = block
       end
 
+      def cursor_sort_at(key)
+        @_default_cursor_sort_at = key.to_sym
+      end
+
       def cursor_sort_order(rank)
         @_default_cursor_sort_order = rank.to_sym
       end
@@ -23,6 +27,10 @@ module Jinrai #:nodoc:
 
       def default_cursor_format
         @_default_cursor_format || Jinrai.config.default_cursor_format
+      end
+
+      def default_cursor_sort_at
+        @_default_cursor_sort_at || Jinrai.config.default_cursor_sort_at
       end
 
       def default_cursor_sort_order


### PR DESCRIPTION
## Overview
 - Add `cursor_sort_at` setting.
   - The setting enables to point at order key, for example: `created_at`.
 - Add 2 alias methods `next_cursor` and `prev_cursor`
 - Fix README 

## Concern
 - I don't add spec, sorry.