### PR TITLE
Github Actionsの設定を追加

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,0 +1,34 @@
+name: rspec
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  rspec:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [2.7, 3.0, 3.1]
+    timeout-minutes: 5
+    services:
+      mysql:
+        image: mysql:5.7
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: bundle install
+        run: bundle install --jobs 4 --retry 3
+      - name: create database
+        run: mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports['3306'] }} -uroot -e "create database jinrai_test"
+      - name: RSpec
+        run: bundle exec rspec

--- a/jinrai.gemspec
+++ b/jinrai.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", ">= 5.1.0"
+  s.add_dependency "rails", "~> 6.0"
 
   s.add_development_dependency "mysql2"
   s.add_development_dependency "rspec-rails"

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -25,10 +25,9 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  adapter: mysql2
+  <<: *default
   database: jinrai_test
-  username: root
-  encoding: utf8
+  host: 127.0.0.1
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is


### PR DESCRIPTION
## 概要
CIの設定が動いていなかったので追加しました

## やったこと
- rspecを実行するところまでのアクションを設定
  - PR作成時、masterにpushされたときに実行されるようにしました
  - 2.7 / 3.0 / 3.1で実行されるようにしました

## その他
そもそもキーワード引数のdeprecation対応だったはずなのに3.0や3.1でもテスト動いているのはなぜでしょうか