### PR TITLE
Ruby3系でも動くようにする

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -8,8 +8,20 @@ jobs:
   rspec:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby: [2.7, 3.0, 3.1]
+        gemfile:
+          - rails_5_2
+          - rails_6_0
+          - rails_6_1
+        exclude:
+          - ruby: 3.0
+            gemfile: rails_5_2
+          - ruby: 3.1
+            gemfile: rails_5_2
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
     timeout-minutes: 5
     services:
       mysql:
@@ -26,8 +38,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: bundle install
-        run: bundle install --jobs 4 --retry 3
       - name: create database
         run: mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports['3306'] }} -uroot -e "create database jinrai_test"
       - name: RSpec

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 5.2.8"
+
+gemspec path: "../"

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 6.0.5"
+
+gemspec path: "../"

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 6.1.6"
+
+gemspec path: "../"

--- a/jinrai.gemspec
+++ b/jinrai.gemspec
@@ -14,7 +14,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", "~> 6.0"
+  s.add_dependency "rails", ">= 5.2.0", "< 7"
+  s.add_dependency "psych", "< 4.0"
 
   s.add_development_dependency "mysql2"
   s.add_development_dependency "rspec-rails"

--- a/lib/jinrai/active_record/result.rb
+++ b/lib/jinrai/active_record/result.rb
@@ -3,9 +3,9 @@ module Jinrai
     module Result
       attr_writer :is_cursored
 
-      def initialize(*a)
+      def initialize(klass, **args)
         @is_cursored = false
-        super(*a)
+        super
       end
 
       def cursored?


### PR DESCRIPTION
- CIの設定を修正
  - rails5.2, 6.0, 6.1で実行
  - ruby2.7, 3.0, 3.1で実行
- ruby3系でもコードが動くように修正
  - psychのbreaking changeがあるので4未満に固定
  - キーワード引数の受け取り方が変わるので修正
