### PR TITLE
psychのバージョン指定を解除

### DIFF
--- a/jinrai.gemspec
+++ b/jinrai.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "rails", "~> 7.0"
-  s.add_dependency "psych", "< 4.0"
+  s.add_dependency "psych"
   s.add_dependency "sprockets-rails"
 
   s.add_development_dependency "mysql2"


### PR DESCRIPTION
Ruby3.1以降でpsychが4系になり、`YAML.load`周りの互換性の問題が起こる可能性があったため固定していましたが、
今後の更新を考えて外します