### PR TITLE
:+1: Introduce multiple orders API

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,7 +1,9 @@
 # Jinrai
-Jinraiはカーソルベースのページネータです。
+
+Jinrai はカーソルベースのページネータです。
 
 ## 使い方
+
 ```ruby
 # config/initializers/jinrai.rb
 
@@ -13,6 +15,7 @@ end
 ```
 
 モデルごとにリクエスト毎のレコード返却件数, カーソルのフォーマットを指定することができます。
+
 ```ruby
 # app/model/user.rb
 
@@ -34,7 +37,8 @@ User.after(cursor) # カーソルが指し示すレコード以降のデータ�
 User.before(cursor) # カーソルが指し示すレコード以前のデータを返します
 ```
 
-`.cursor`メソッドは `till`と`since`,`sort_at`の3つの引数を持っていて, 任意の範囲のレコードを取り出したり、特定の属性で並び替えることができます.
+`.cursor`メソッドは `till`と`since`,`sort_at`の 3 つの引数を持っていて, 任意の範囲のレコードを取り出したり、特定の属性で並び替えることができます.
+
 ```ruby
 since_cursor = User.cursor.till_cursor
 User.cursor(since: since_cursor) # since_cursor移行のレコードセットを返します
@@ -46,9 +50,17 @@ User.cursor(till: till_cursor) # till_cursor以前のレコードセットを返
 User.cursor(since: since_cursor, till: till_cursor)
 ```
 
-カーソルはコレクションに対して`#since_cursor`, `#till_cursor`を呼び出すか、modelのインスタンスに対して`#to_cursor`を呼び出すことで取得できます。
+カーソルはコレクションに対して`#since_cursor`, `#till_cursor`を呼び出すか、model のインスタンスに対して`#to_cursor`を呼び出すことで取得できます。
+
 ```ruby
 users = User.cursor
 users.since_cursor # コレクションの最初のレコードを指し示すカーソルを返します
 users.till_cursor # コレクションの最後のレコードを指し示すカーソルを返します
+```
+
+`.cursor` メソッドは `order` 引数を使って、順序を指定することができます。
+(`sort_at` は古い仕様なので、`order`の使用をお勧めします)
+
+```ruby
+User.cursor(order: { age: :desc, name: :asc })
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Jinrai
+
 Jinrai is a awesome cursor based paginator
 
 ## Usage
+
 ```ruby
 # config/initializers/jinrai.rb
 
@@ -31,6 +33,7 @@ User.cursor.count #=> 20
 ```
 
 `.cursor` has two arguments, `till` and `since`, and by passing them we can get record collection of arbitrary interval.
+
 ```ruby
 since_cursor = User.cursor.till_cursor
 User.cursor(since: since_cursor) # return records older than the record pointed by the cursor
@@ -42,13 +45,22 @@ User.cursor(since: since_cursor, till: till_cursor) # return records newer than 
 ```
 
 Get cursor by calling `since_cursor` or `till_cursor`.
+
 ```ruby
 users = User.cursor
 users.since_cursor # this cursor points first record of User collection
 users.till_cursor # this cursor points last record of User collection
 ```
 
+`.cursor` allows to specify order with `order` argument.
+(`sort_at` is an old argument, please use `order`.)
+
+```ruby
+User.cursor(order: { age: :desc, name: :asc })
+```
+
 ## Installation
+
 Add this line to your application's Gemfile:
 
 ```ruby
@@ -56,43 +68,51 @@ gem 'jinrai'
 ```
 
 And then execute:
+
 ```bash
 $ bundle
 ```
 
 Or install it yourself as:
+
 ```bash
 $ gem install jinrai
 ```
 
 ## Contributing
+
 1. Fork then clone this repo:
+
 ```bash
 git clone git@github.com:YOUR_USERNAME/jinrai.git
 ```
 
 1. Create database
+
 ```
 $ mysql --host 127.0.0.1  -uroot -e "create database jinrai_test"
 ```
 
 1. setup dependencies via bundler:
+
 ```bash
 bundle install
 ```
 
 1. Make sure the spec pass:
+
 ```bash
 bundle exec rspec
 ```
 
 1. Make your change, and write spec, make sure test pass:
+
 ```bash
 bundle exec rspec
 ```
 
 1. write a good commit message, push to your fork, then submit PullRequest.
 
-
 ## License
+
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/lib/jinrai/active_record/finder_methods_with_multiple_orders.rb
+++ b/lib/jinrai/active_record/finder_methods_with_multiple_orders.rb
@@ -1,0 +1,98 @@
+require 'jinrai/active_record/cursor_methods'
+
+module Jinrai
+  module ActiveRecord #:nodoc:
+    module FinderMethodsWithMultipleOrders
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        private
+
+        def after_with_multiple_orders(cursor, options)
+          relation, multiple_orders = pre_proc(options)
+          relation = cursoring_with_multiple_orders(relation, cursor, multiple_orders)
+          relation.order(multiple_orders).extending_cursor
+        end
+
+        def before_with_multiple_orders(cursor, options)
+          relation, multiple_orders = pre_proc(options)
+          relation = cursoring_with_multiple_orders(relation, cursor, multiple_orders, reverse: true)
+          relation.order(multiple_orders).extending_cursor
+        end
+
+        def cursor_with_multiple_orders(options)
+          relation, multiple_orders = pre_proc(options)
+
+          relation = cursoring_with_multiple_orders(relation, options[:since], multiple_orders)
+          relation = cursoring_with_multiple_orders(relation, options[:till], multiple_orders, reverse: true)
+
+          relation.order(multiple_orders).extending_cursor
+        end
+
+        def cursoring_with_multiple_orders(relation, cursor, multiple_orders, reverse: false)
+          return relation unless cursor
+
+          rank_by_sort_key = to_rank_by_sort_key(multiple_orders, reverse: reverse)
+
+          attributes = default_attributes_from_cursor.call(decode_cursor(cursor))
+          pointed = find_by!(attributes)
+
+          exprs = []
+          last_eq_expr = nil
+          rank_by_sort_key.each do |sort_key, rank|
+            if last_eq_expr.nil?
+              exprs << arel_table[sort_key].send(rank, pointed[sort_key])
+              last_eq_expr = arel_table[sort_key].eq(pointed[sort_key])
+            else
+              exprs << arel_table.grouping(
+                last_eq_expr.and(
+                  arel_table[sort_key].send(rank, pointed[sort_key])
+                )
+              )
+              last_eq_expr = last_eq_expr.and(arel_table[sort_key].eq(pointed[sort_key]))
+            end
+          end
+
+          relation.where(
+            exprs.inject(::Arel::Nodes::False.new) { |c, e| c.or(e) } # connect with OR
+          )
+        rescue ::ActiveRecord::StatementInvalid => e
+          # TODO: modify error message
+          raise Jinrai::ActiveRecord::StatementInvalid, e
+        rescue ::ActiveRecord::RecordNotFound
+          raise Jinrai::ActiveRecord::RecordNotFound,
+            "Could not find record cursor pointing, Check cursor_format settings."
+        end
+
+        def pre_proc(options)
+          raise ArgumentError, "order option is required" unless options[:order].present?
+          raise ArgumentError, "order option and sort_at option cannot be not used together" if options[:sort_at].present?
+
+          relation = all
+
+          raise "Cannot use order method before cursor/after/before methods" if relation.order_values.present?
+
+          multiple_orders = options[:order]
+          unless multiple_orders.has_key?(primary_key.to_sym)
+            multiple_orders = multiple_orders.merge(id: :asc)
+          end
+
+          return relation, multiple_orders
+        end
+
+        def to_rank_by_sort_key(multiple_orders, reverse: false)
+          multiple_orders.map do |sort_key, sort_order|
+            case sort_order
+            when :desc
+              [sort_key, (reverse ? :gt : :lt)]
+            when :asc
+              [sort_key, (reverse ? :lt : :gt)]
+            else
+              raise ArgumentError, "sort_order must be :desc or :asc"
+            end
+          end.to_h
+        end
+      end
+    end
+  end
+end

--- a/spec/active_record/finder_methods_with_multiple_orders_spec.rb
+++ b/spec/active_record/finder_methods_with_multiple_orders_spec.rb
@@ -1,0 +1,176 @@
+require "rails_helper"
+
+RSpec.describe Jinrai::ActiveRecord::FinderMethods do
+  before do
+    User.cursor_per 3
+
+    now = Time.zone.now
+    create(:user, age: 5, updated_at: now)
+    create(:user, age: 4, updated_at: now + 2.second)
+    create(:user, age: 3, updated_at: now + 1.second)
+    create(:user, age: 2, updated_at: now + 1.second)
+    create(:user, age: 1, updated_at: now + 2.second)
+
+    create(:user, age: 4, updated_at: now)
+    create(:user, age: 5, updated_at: now)
+  end
+
+  describe ".cursor" do
+    shared_examples_for "return correct collection" do
+      it "should return correct collection" do
+        users1 = User.cursor(order: order)
+        _users1 = User.order(order).limit(3)
+
+        expect(users1.ids).to eq _users1.ids
+
+        # steps for checking passing since parameter
+        since_cursor1 = users1.till_cursor
+
+        users2  = User.cursor(since: since_cursor1, order: order)
+        _users2 = User.where.not(id: _users1.ids).order(order).limit(3)
+
+        expect(users2.ids).to eq _users2.ids
+
+        since_cursor2 = users2.till_cursor
+
+        users3  = User.cursor(since: since_cursor2, order: order)
+        _users3 = User.where.not(id: (_users1.ids + _users2.ids)).order(order).limit(3)
+
+        expect(users3.count).to eq 1
+        expect(users3.ids).to eq _users3.ids
+
+
+        # steps for checking passing till parameter
+        till_cursor2 = users2.since_cursor
+
+        till_users  = User.cursor(till: till_cursor2, order: order)
+        _till_users = User.order(order).limit(3)
+
+        expect(till_users.ids).to eq _till_users.ids
+      end
+    end
+
+    context "when sort at one attribute" do
+      let(:order) { { id: :desc } }
+      it_behaves_like "return correct collection"
+    end
+
+    context "when sort at dpuble attributes" do
+      let(:order) { { age: :desc, id: :asc } }
+      it_behaves_like "return correct collection"
+    end
+
+    context "when sort at triple attributes" do
+      let(:order) { { age: :desc, updated_at: :asc, id: :desc } }
+      it_behaves_like "return correct collection"
+    end
+
+    context "when sort without id" do
+      shared_examples_for "return all collection" do
+        it "should return all data" do
+          users1 = User.cursor(order: order)
+          expect(users1.count).to eq 3
+
+          users2  = User.cursor(since: users1.till_cursor, order: order)
+          expect(users2.count).to eq 3
+
+          users3  = User.cursor(since: users2.till_cursor, order: order)
+          expect(users3.count).to eq 1
+
+          expect((users1.ids + users2.ids + users3.ids)).to eq User.order(order.merge(id: :asc)).ids
+        end
+      end
+
+      context "when sort at one attribute" do
+        let(:order) { { age: User.default_cursor_sort_order } }
+        it_behaves_like "return all collection"
+        it "should return same collection from withour multiple orders" do
+          users_with_multiple_orders1 = User.cursor(order: order)
+          users_without_multiple_orders1 = User.cursor(sort_at: :age)
+          expect(users_with_multiple_orders1.ids).to eq users_without_multiple_orders1.ids
+
+          users_with_multiple_orders2 = User.cursor(since: users_with_multiple_orders1.till_cursor, order: order)
+          users_without_multiple_orders2 = User.cursor(since: users_without_multiple_orders1.till_cursor, sort_at: :age)
+          expect(users_with_multiple_orders2.ids).to eq users_without_multiple_orders2.ids
+
+          users_with_multiple_orders3 = User.cursor(since: users_with_multiple_orders2.till_cursor, order: order)
+          users_without_multiple_orders3 = User.cursor(since: users_without_multiple_orders2.till_cursor, sort_at: :age)
+          expect(users_with_multiple_orders3.ids).to eq users_without_multiple_orders3.ids
+        end
+      end
+
+      context "when sort at multiple attributes" do
+        let(:order) { { age: :desc, updated_at: :asc } }
+        it_behaves_like "return all collection"
+      end
+    end
+
+    context "Invalid call" do
+      it "should raise error" do
+        expect { User.cursor(order: { id: :desc }, sort_at: :age) }.to raise_error(ArgumentError)
+        expect { User.order(age: :desc).cursor(order: { id: :desc }) }.to raise_error(RuntimeError, "Cannot use order method before cursor/after/before methods")
+      end
+    end
+  end
+
+  describe ".after" do
+    context "with multiple orders" do
+      let(:order) { { age: :desc, id: :asc } }
+      it "should return correct collection" do
+        users1 = User.cursor(order: order)
+        _users1 = User.order(order).limit(3)
+
+        expect(users1.ids).to eq _users1.ids
+
+        since_cursor1 = users1.till_cursor
+
+        users2  = User.after(since_cursor1, order: order)
+        _users2 = User.where.not(id: _users1.ids).order(order).limit(3)
+        expect(users2.ids).to eq _users2.ids
+      end
+    end
+
+    context "with multiple orders (but actually one attribute)" do
+      let(:order) { { age: User.default_cursor_sort_order } }
+      it "should return same collection from no multiple orders" do
+        users_with_multiple_orders1 = User.cursor(order: order)
+        users_without_multiple_orders1 = User.cursor(sort_at: :age)
+        expect(users_with_multiple_orders1.ids).to eq users_without_multiple_orders1.ids
+
+        users_with_multiple_orders2 = User.cursor(since: users_with_multiple_orders1.till_cursor, order: order)
+        users_without_multiple_orders2 = User.after(users_without_multiple_orders1.till_cursor, sort_at: :age)
+        expect(users_with_multiple_orders2.ids).to eq users_without_multiple_orders2.ids
+
+        users_with_multiple_orders3 = User.cursor(since: users_with_multiple_orders2.till_cursor, order: order)
+        users_without_multiple_orders3 = User.after(users_without_multiple_orders2.till_cursor, sort_at: :age)
+        expect(users_with_multiple_orders3.ids).to eq users_without_multiple_orders3.ids
+      end
+    end
+  end
+
+  describe ".before" do
+    context "with multiple orders" do
+      let(:order) { { age: :desc, id: :asc } }
+      it "should return correct collection" do
+        users1 = User.cursor(order: order)
+        users2  = User.cursor(since: users1.till_cursor, order: order)
+
+        users = User.before(users2.since_cursor, order: order)
+        expect(users.ids).to eq users1.ids
+      end
+    end
+
+    context "with multiple orders (but actually one attribute)" do
+      let(:order) { { age: User.default_cursor_sort_order } }
+      it "should return same collection from no multiple orders" do
+        users1 = User.cursor(order: order)
+        users2  = User.cursor(since: users1.till_cursor, order: order)
+
+        users_without_multiple_orders = User.before(users2.since_cursor, sort_at: :age)
+        users_with_multiple_orders = User.before(users2.since_cursor, order: order)
+        expect(users_without_multiple_orders.ids).to eq users_with_multiple_orders.ids
+        expect(users_with_multiple_orders.ids).to eq users1.ids
+      end
+    end
+  end
+end

--- a/spec/active_record/finder_methods_with_multiple_orders_spec.rb
+++ b/spec/active_record/finder_methods_with_multiple_orders_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 
-RSpec.describe Jinrai::ActiveRecord::FinderMethods do
+RSpec.describe Jinrai::ActiveRecord::FinderMethodsWithMultipleOrders do
   before do
+    travel_to(Time.zone.now)
     User.cursor_per 3
 
     now = Time.zone.now
@@ -38,7 +39,6 @@ RSpec.describe Jinrai::ActiveRecord::FinderMethods do
 
         expect(users3.count).to eq 1
         expect(users3.ids).to eq _users3.ids
-
 
         # steps for checking passing till parameter
         till_cursor2 = users2.since_cursor


### PR DESCRIPTION
現状、ソートキーは `sort_at`で一つのみが指定可能ですが、複数列でソートしたいときに対応できません。
（実際に複数列のソートをしたいと思ったのですが、できなくて諦めた経緯があります）
そこで、複数列でのソートにも対応するように拡張します。

## 変更内容
`cursor/before/after`に`order`を受けとれるようにします。この`order`にはARの`order`メソッドに渡す相当の値を指定することを期待しています。使い方は以下のような感じです。

```ruby
User.cursor(order: { age: :desc, id: :asc })
```

`order`が追加された以外は何も変わっていません。なので、引き続き`sort_at`が利用可能です。

これで問題ないなら、READMEとかも更新します